### PR TITLE
Disable AMD detection in browserify-generated bundle file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ var zip = require("gulp-zip");
 var browserify = require("browserify");
 var debowerify = require('debowerify');
 var source = require("vinyl-source-stream");
+var deamd = require('deamd');
 var through2 = require("through2");
 var jsforce = require("jsforce");
 
@@ -35,7 +36,10 @@ gulp.task("build", function() {
     entries: ["./src/scripts/"+ componentName +".js"],
     standalone: componentName
   }).transform(debowerify)
-  .bundle().pipe(source(componentName + ".resource")).pipe(gulp.dest("pkg/staticresources/"));
+  .bundle()
+  .pipe(source(componentName + ".resource"))
+  .pipe(deamd())
+  .pipe(gulp.dest("pkg/staticresources/"));
 });
 
 gulp.task("deploy", function() {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "jsforce": "^1.4.1",
+    "deamd": "^1.0.0",
     "gulp": "^3.8.11",
     "gulp-zip": "^3.0.2",
     "through2": "^0.6.5",


### PR DESCRIPTION
If the RequireJS AMD loader is present in the environment, the bundle file generated by browserify with standalone option wrongly assumes it is loaded by AMD loader, even if it is used in standalone.

As some Lightning components are using RequireJS as its script loader, the generated bundle script conflicts with these components (typically leads to "Mismatched anonymous define" error).

This pull request fix errors of wrong AMD detection by applying DeAMD transform to the bundle script.
